### PR TITLE
Added LWP::Protocol::https in Makefile prereq's

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,6 +8,6 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
   NAME         => 'WWW::Mailgun',
   VERSION_FROM => 'lib/WWW/Mailgun.pm',
-  PREREQ_PM    => {'JSON' => 0, 'Digest::SHA1' => 0, 'LWP::UserAgent' => 0, 'MIME::Base64' => 0},
+  PREREQ_PM    => {'JSON' => 0, 'Digest::SHA1' => 0, 'LWP::UserAgent' => 0, 'MIME::Base64' => 0, 'LWP::Protocol::https' => 0},
   AUTHOR       => 'George Tsafas <elb0w@elbowrage.com>'
 );


### PR DESCRIPTION
By default, libwww does not appear to have HTTPS support. 

The tests fail and the module reports an exit code of >= 500. 

Upon closer inspection of the response object (below), it appears LWP::Protocol::https should be installed in order to enable HTTPS. All tests pass after that. 

$VAR1 = bless( {
                 '_content' => 'LWP will support https URLs if the LWP::Protocol::https module
is installed.
',
                 '_rc' => 501,
                 '_headers' => bless( {
                                        'client-warning' => 'Internal response',
                                        'client-date' => 'Tue, 17 Jul 2012 11:51:38 GMT',
                                        'content-type' => 'text/plain'
                                      }, 'HTTP::Headers' ),
                 '_msg' => 'Protocol scheme \'https\' is not supported (LWP::Protocol::https not installed)',
                 '_request' => bless( {
                                        '_content' => '',
                                        '_uri' => bless( do{(my $o = 'https://api.mailgun.net/v2/fruity.mailgun.org/stats')}, 'URI::https' ),
                                        '_headers' => bless( {
                                                               'user-agent' => 'libwww-perl/6.04',
                                                               'authorization' => 'Basic YXBpOmtleS0zbzhpdXJ1MDcwMDNzeHo0dmgybXEteHNwNWRpOWMtNQ==
'
                                                             }, 'HTTP::Headers' ),
                                        '_method' => 'GET'
                                      }, 'HTTP::Request' )
               }, 'HTTP::Response' );
