### PR TITLE
Add 'inline' field

### DIFF
--- a/lib/WWW/Mailgun.pm
+++ b/lib/WWW/Mailgun.pm
@@ -138,6 +138,7 @@ sub _prepare_content {
                 last;
             }
             $value = [ $value ] if $option eq 'attachment';
+            $value = [ $value ] if $option eq 'inline'; #Mailgun also supports inline
             push @$content, $option => $value;
         }
     }


### PR DESCRIPTION
Inline is also a parameter supported by Mailgun.
Tested this also. Use this in your email to display an inline image:
```
<img src="img:filename.jpg">
```